### PR TITLE
Feat add formated pasting from clipboard

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -1241,6 +1241,7 @@ a.phabricator-remarkup-embed-image img{background:white;}
       if (node.nodeType === 3) return node.nodeValue.replace(/[\r\n\t]+/g, ' ');
       if (node.nodeType !== 1) return '';
       var tag = node.tagName.toUpperCase(), kids = Array.from(node.childNodes);
+      if (/^(STYLE|SCRIPT|HEAD|META|LINK|NOSCRIPT)$/.test(tag)) return '';
       if (tag === 'BR') return '\n';
       if (tag === 'HR') return '\n\n----\n\n';
       if (tag === 'IMG') return '';

--- a/plugin.js
+++ b/plugin.js
@@ -1314,7 +1314,7 @@ a.phabricator-remarkup-embed-image img{background:white;}
       }
       var inner = kids.map(function (c) { return cvtHtml(c, listDepth); }).join('');
       if (tag === 'STRONG' || tag === 'B') return '**' + inner.trim() + '**';
-      if (tag === 'EM' || tag === 'I') return '*' + inner.trim() + '*';
+      if (tag === 'EM' || tag === 'I') return '//' + inner.trim() + '//';
       if (tag === 'CODE') return (node.parentElement && node.parentElement.tagName === 'PRE') ? inner : '`' + inner.trim() + '`';
       if (tag === 'DEL' || tag === 'S') return '~~' + inner.trim() + '~~';
       if (tag === 'A') {

--- a/plugin.js
+++ b/plugin.js
@@ -1278,13 +1278,22 @@ a.phabricator-remarkup-embed-image img{background:white;}
       if (tag === 'UL' || tag === 'OL') {
         var indent = '  '.repeat(listDepth);
         var isOl = tag === 'OL';
-        var olIdx = 0;
+        var olStart = parseInt(node.getAttribute('start'), 10);
+        var olIdx = isOl ? (isNaN(olStart) ? 1 : olStart) : 0;
         var liLines = [];
         Array.from(node.children).forEach(function (child) {
           if (child.tagName === 'LI') {
             var liTxt = Array.from(child.childNodes).filter(function (c) { return !(c.nodeType === 1 && (c.tagName === 'UL' || c.tagName === 'OL')); }).map(function (c) { return cvtHtml(c, listDepth + 1); }).join('').trim();
             var nested = Array.from(child.childNodes).filter(function (c) { return c.nodeType === 1 && (c.tagName === 'UL' || c.tagName === 'OL'); }).map(function (c) { return cvtHtml(c, listDepth + 1); }).join('').replace(/^\n+|\n+$/g, '');
-            var pfx = indent + (isOl ? (++olIdx) + '. ' : '+ ');
+            var pfx;
+            if (isOl) {
+              var liValue = parseInt(child.getAttribute('value'), 10);
+              var itemNumber = isNaN(liValue) ? olIdx : liValue;
+              pfx = indent + itemNumber + '. ';
+              olIdx = itemNumber + 1;
+            } else {
+              pfx = indent + '+ ';
+            }
             liLines.push(pfx + liTxt + (nested ? '\n' + nested : ''));
           } else if (child.tagName === 'UL' || child.tagName === 'OL') {
             // Nested list as a direct child of the parent list (invalid HTML but

--- a/plugin.js
+++ b/plugin.js
@@ -1287,9 +1287,12 @@ a.phabricator-remarkup-embed-image img{background:white;}
         return '\n' + liLines.join('\n') + '\n';
       }
       if (tag === 'TABLE') {
-        node.querySelectorAll('br').forEach(function (br) { br.replaceWith('\n'); });
-        var arr = Array.from(node.rows).map(function (row) { return Array.from(row.cells).map(function (c) { return c.textContent.trim(); }); });
-        return '\n' + arr.map(function (row) { return '| ' + row.map(function (c) { return c.replace(/\n/g, '{newline}'); }).join(' | ') + ' |'; }).join('\n') + '\n';
+        var arr = Array.from(node.rows).map(function (row) {
+          return Array.from(row.cells).map(function (c) {
+            return Array.from(c.childNodes).map(function (child) { return cvtHtml(child, 0); }).join('').trim().replace(/\n/g, '{newline}');
+          });
+        });
+        return '\n' + arr.map(function (row) { return '| ' + row.join(' | ') + ' |'; }).join('\n') + '\n';
       }
       var inner = kids.map(function (c) { return cvtHtml(c, listDepth); }).join('');
       if (tag === 'STRONG' || tag === 'B') return '**' + inner.trim() + '**';

--- a/plugin.js
+++ b/plugin.js
@@ -1234,11 +1234,79 @@ a.phabricator-remarkup-embed-image img{background:white;}
     if (document.activeElement.type !== 'textarea') return;
     var html = e.clipboardData.getData('text/html'); if (!html) return;
     var doc2 = new DOMParser().parseFromString(html, 'text/html');
-    var tbl = doc2.querySelector('table'); if (!tbl) return;
-    var arr = Array.from(tbl.rows).map(function (row) { return Array.from(row.cells).map(function (c) { c.querySelectorAll('br').forEach((br) => br.replaceWith('\n')); return (c.textContent || '').trim(); }); });
-    var md = arr.map(function (row) { return '\n| ' + row.map(function (c) { return c.replace(/\n/g, '{newline}'); }).join(' | ') + ' |'; }).join('');
+    var body = doc2.body;
+    // Only intercept if there is meaningful formatting to convert
+    if (!body.querySelector('h1,h2,h3,h4,h5,h6,ul,ol,pre,blockquote,table,strong,b,em,i,code,a[href],del,s,hr')) return;
+    function cvtHtml(node, listDepth) {
+      if (node.nodeType === 3) return node.nodeValue.replace(/[\r\n\t]+/g, ' ');
+      if (node.nodeType !== 1) return '';
+      var tag = node.tagName.toUpperCase(), kids = Array.from(node.childNodes);
+      if (tag === 'BR') return '\n';
+      if (tag === 'HR') return '\n\n----\n\n';
+      if (tag === 'IMG') return '';
+      if (/^H[1-6]$/.test(tag)) {
+        var lvl = +tag[1], marks = '#'.repeat(lvl);
+        return '\n' + marks + ' ' + kids.map(function (c) { return cvtHtml(c, listDepth); }).join('').trim() + '\n';
+      }
+      if (tag === 'P') {
+        return '\n' + kids.map(function (c) { return cvtHtml(c, listDepth); }).join('').trim() + '\n';
+      }
+      if (tag === 'DIV') {
+        var di = kids.map(function (c) { return cvtHtml(c, listDepth); }).join('');
+        return /\n$/.test(di) ? di : di + '\n';
+      }
+      if (tag === 'BLOCKQUOTE') {
+        var bi = kids.map(function (c) { return cvtHtml(c, listDepth); }).join('').trim();
+        return '\n' + bi.split('\n').map(function (l) { return '> ' + l; }).join('\n') + '\n';
+      }
+      if (tag === 'PRE') {
+        var codeEl = node.querySelector('code');
+        var preText = (codeEl || node).textContent;
+        var m = codeEl && codeEl.className.match(/language-(\w+)/);
+        return '\n```' + (m ? m[1] : '') + '\n' + preText.replace(/\n$/, '') + '\n```\n';
+      }
+      if (tag === 'UL' || tag === 'OL') {
+        var indent = '  '.repeat(listDepth);
+        var isOl = tag === 'OL';
+        var olIdx = 0;
+        var liLines = [];
+        Array.from(node.children).forEach(function (child) {
+          if (child.tagName === 'LI') {
+            var liTxt = Array.from(child.childNodes).filter(function (c) { return !(c.nodeType === 1 && (c.tagName === 'UL' || c.tagName === 'OL')); }).map(function (c) { return cvtHtml(c, listDepth + 1); }).join('').trim();
+            var nested = Array.from(child.childNodes).filter(function (c) { return c.nodeType === 1 && (c.tagName === 'UL' || c.tagName === 'OL'); }).map(function (c) { return cvtHtml(c, listDepth + 1); }).join('').replace(/^\n+|\n+$/g, '');
+            var pfx = indent + (isOl ? (++olIdx) + '. ' : '+ ');
+            liLines.push(pfx + liTxt + (nested ? '\n' + nested : ''));
+          } else if (child.tagName === 'UL' || child.tagName === 'OL') {
+            // Nested list as a direct child of the parent list (invalid HTML but
+            // common in content pasted from Google Docs and many websites).
+            var r = cvtHtml(child, listDepth + 1).replace(/^\n+|\n+$/g, '');
+            if (r) liLines.push(r);
+          }
+        });
+        return '\n' + liLines.join('\n') + '\n';
+      }
+      if (tag === 'TABLE') {
+        node.querySelectorAll('br').forEach(function (br) { br.replaceWith('\n'); });
+        var arr = Array.from(node.rows).map(function (row) { return Array.from(row.cells).map(function (c) { return c.textContent.trim(); }); });
+        return '\n' + arr.map(function (row) { return '| ' + row.map(function (c) { return c.replace(/\n/g, '{newline}'); }).join(' | ') + ' |'; }).join('\n') + '\n';
+      }
+      var inner = kids.map(function (c) { return cvtHtml(c, listDepth); }).join('');
+      if (tag === 'STRONG' || tag === 'B') return '**' + inner.trim() + '**';
+      if (tag === 'EM' || tag === 'I') return '*' + inner.trim() + '*';
+      if (tag === 'CODE') return (node.parentElement && node.parentElement.tagName === 'PRE') ? inner : '`' + inner.trim() + '`';
+      if (tag === 'DEL' || tag === 'S') return '~~' + inner.trim() + '~~';
+      if (tag === 'A') {
+        var href = node.getAttribute('href') || '';
+        var linkTxt = inner.trim();
+        if (href && linkTxt && linkTxt !== href) return '[' + linkTxt + '](' + href + ')';
+        return href ? '<' + href + '>' : inner;
+      }
+      return inner;
+    }
+    var result = cvtHtml(body, 0).replace(/\n{3,}/g, '\n\n').trim();
+    if (!result) return;
     var ta = document.activeElement, s = ta.selectionStart, end = ta.selectionEnd;
-    ta.setRangeText(md, s, end, 'select'); e.preventDefault();
+    ta.setRangeText(result, s, end, 'select'); e.preventDefault();
   });
 
   (function () {

--- a/plugin.js
+++ b/plugin.js
@@ -1237,6 +1237,15 @@ a.phabricator-remarkup-embed-image img{background:white;}
     var body = doc2.body;
     // Only intercept if there is meaningful formatting to convert
     if (!body.querySelector('h1,h2,h3,h4,h5,h6,ul,ol,pre,blockquote,table,strong,b,em,i,code,a[href],del,s,hr')) return;
+    /**
+     * Convert a DOM node subtree into Phabricator/Markdown-like remarkup text.
+     *
+     * Traverses the node and its children and produces plain-text remarkup suitable for insertion into a remarkup textarea (handles headings, paragraphs/divs, lists, blockquotes, fenced code blocks, tables, inline formatting, links, horizontal rules, and basic nested lists).
+     *
+     * @param {Node} node - The DOM node to convert.
+     * @param {number} listDepth - Current list nesting depth used to compute indentation (0 for top level).
+     * @returns {string} The converted remarkup text for the given node subtree.
+     */
     function cvtHtml(node, listDepth) {
       if (node.nodeType === 3) return node.nodeValue.replace(/[\r\n\t]+/g, ' ');
       if (node.nodeType !== 1) return '';

--- a/plugin.js
+++ b/plugin.js
@@ -1307,7 +1307,9 @@ a.phabricator-remarkup-embed-image img{background:white;}
     var result = cvtHtml(body, 0).replace(/\n{3,}/g, '\n\n').trim();
     if (!result) return;
     var ta = document.activeElement, s = ta.selectionStart, end = ta.selectionEnd;
-    ta.setRangeText(result, s, end, 'select'); e.preventDefault();
+    ta.setRangeText(result, s, end, 'select');
+    ta.dispatchEvent(new Event('input', { bubbles: true }));
+    e.preventDefault();
   });
 
   (function () {


### PR DESCRIPTION
This pull request significantly improves the HTML-to-Markdown conversion logic when pasting formatted content into a textarea. Instead of handling only tables, the new implementation supports a wide range of HTML elements and produces cleaner, more accurate Markdown output.

**Enhanced HTML-to-Markdown conversion:**

* Replaces the previous table-only handling with a comprehensive `cvtHtml` function that converts headings, lists (ordered and unordered), blockquotes, code/pre/code blocks, tables, and inline formatting (bold, italic, code, links, strikethrough) into appropriate Markdown syntax.
* Only triggers conversion if the pasted HTML contains meaningful formatting (e.g., headings, lists, tables, formatting tags), avoiding unnecessary processing for plain text.
* Ensures changes to the textarea are properly registered by dispatching an input event after setting the converted Markdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Paste now intelligently converts rich HTML into compatible plain/markdown-like text when inserting into text areas, preserving headings, lists (with nesting), blockquotes, fenced code blocks, tables, emphasis, links, and strikethrough.
  * Excessive newlines are normalized and converted content is inserted into the current selection to maintain formatting and cursor position.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sciyen/Phabricator-Editor-Plugin/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->